### PR TITLE
Allow Symfony 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     },
     "require": {
-        "symfony/finder":                               "~2.8|~3.0",
+        "symfony/finder":                               "~2.8|~3.0|~4.0",
         "php":                                          ">=5.4"
     },
     "require-dev": {
@@ -22,7 +22,7 @@
         "symfony/dependency-injection":                 "~2.8|~3.0",
         "symfony/config":                               "~2.8|~3.0",
         "squizlabs/php_codesniffer":                    "@stable",
-        "phpunit/phpunit":                              "@stable"
+        "phpunit/phpunit":                              "^5"
     },
     "suggest": {
         "symfony/http-kernel": "to search for classes inside bundles registered with AppKernel (Symfony)"


### PR DESCRIPTION
Nothing major changed in finder in 4.0. Also we need to lock to phpunit 5, since testcases are not compatible with higher versions